### PR TITLE
Adicionando lógica para o comando de processamento UART para desligar LEDs

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -11,7 +11,7 @@
                 "${workspaceFolder}/build/generated/pico_base/pico/config_autogen.h"
             ],
             "defines": [],
-            "compilerPath": "${userHome}/.pico-sdk/toolchain/13_3_Rel1/bin/arm-none-eabi-gcc.exe",
+            "compilerPath": "${userHome}/.pico-sdk/toolchain/13_3_Rel1/bin/arm-none-eabi-gcc",
             "compileCommands": "${workspaceFolder}/build/compile_commands.json",
             "cStandard": "c17",
             "cppStandard": "c++14",

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,9 +1,9 @@
 {
     "recommendations": [
-        "marus25.cortex-debug",
-        "ms-vscode.cpptools",
         "ms-vscode.cpptools-extension-pack",
-        "ms-vscode.vscode-serial-monitor",
-        "raspberry-pi.raspberry-pi-pico"
+        "raspberry-pi.raspberry-pi-pico",
+        "ms-vscode.cpptools",
+        "marus25.cortex-debug",
+        "ms-vscode.vscode-serial-monitor"
     ]
 }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,17 @@
+# == DO NOT EDIT THE FOLLOWING LINES for the Raspberry Pi Pico VS Code Extension to work ==
+if(WIN32)
+    set(USERHOME $ENV{USERPROFILE})
+else()
+    set(USERHOME $ENV{HOME})
+endif()
+set(sdkVersion 2.1.0)
+set(toolchainVersion 13_3_Rel1)
+set(picotoolVersion 2.1.0)
+set(picoVscode ${USERHOME}/.pico-sdk/cmake/pico-vscode.cmake)
+if (EXISTS ${picoVscode})
+    include(${picoVscode})
+endif()
+# ====================================================================================
 # Generated Cmake Pico project file
 
 cmake_minimum_required(VERSION 3.13)

--- a/uart.c
+++ b/uart.c
@@ -29,9 +29,11 @@ void processar_comando(const char *command) {
     } else if (strcmp(command, "BLUE") == 0) {
         
     } else if (strcmp(command, "WHITE") == 0) {
-        
+    
         
     } else if (strcmp(command, "OFF") == 0) {
+        controlar_led(0);
+        printf("\nLEDs desligados!\n");
         
     } else if (strcmp(command, "BUZZER") == 0) {
         


### PR DESCRIPTION
Este PR adiciona lógica para desligar todos os leds, enviado o parâmetro 0 para a função `controlar_led`